### PR TITLE
docs: summarize project plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,67 @@ video ID:
 
 The Job uses the backend image to call the API and queue analysis for
 `videoId`.
+
+## Project Plan Summary
+The repository was bootstrapped from an extensive ChatGPT planning session.
+The full transcript is available in [`DanceyChatGPT.md`](DanceyChatGPT.md).
+Major steps from that plan are summarized below:
+
+1. **Vision, Scope & Constraints** – Detect dance moves in short videos and
+   let users compose dances; MVP targets single-dancer uploads, 2D pose
+   extraction, heuristic segmentation, and a small move taxonomy.
+2. **Move Taxonomy & Labeling** – Define a hierarchical move ontology, provide
+   exemplars and annotation guidelines, and version the taxonomy with tools
+   like CVAT or Label Studio.
+3. **Computer Vision & ML** – Use MoveNet/BlazePose for keypoints, smooth and
+   normalize poses, segment motion via energy/change-point detection, and
+   identify moves through template matching or learned classifiers.
+4. **Data Pipeline & Infrastructure** – Ingest uploads to object storage,
+   process them through GPU workers (pose → features → segmentation →
+   identification), and store results in Postgres with optional search and
+   caching layers.
+5. **Backend Services & Data Model** – FastAPI endpoints handle uploads,
+   analysis jobs, taxonomy CRUD, search, and dance composition, backed by
+   tables for users, videos, segments, moves, and compositions.
+6. **Web App & UX** – Next.js frontend offers upload/analysis status, move
+   index pages, and a drag‑and‑drop composer for assembling new dances.
+7. **Quality & Human‑in‑the‑Loop** – Track metrics like IoU and
+   precision/recall, surface low‑confidence segments for annotation, and allow
+   user corrections to improve models.
+8. **Safety & Compliance** – Respect content rights, handle takedowns, enforce
+   privacy policies, and filter sensitive content.
+9. **Scalability & Performance** – Target ~60–120 videos per GPU hour, aim for
+   analysis latency under twice the clip length, and use quantized models and
+   batching to control cost.
+10. **Roadmap** – Phase 0 foundations, Phase 1 MVP analysis, Phase 2 learned
+    identification, Phase 3 composer & sharing, and Phase 4 robustness &
+    scale.
+11. **Data & Model Training** – Collect consented clips, augment data,
+    train TCN/Transformer models on joint features, and version datasets and
+    models with tools like DVC and MLflow.
+12. **Edge Cases & Heuristics** – Handle cuts, tempo shifts, occlusion, mirror
+    detection, and non‑dance segments.
+13. **Security & Reliability** – Perform AV scanning, rate limiting, backups,
+    audit logging, and maintain clear job state transitions.
+14. **Team, Budget & Deliverables** – Outline required roles, monthly cost
+    estimates, and an MVP checklist (taxonomy, analysis pipeline, move index,
+    composer, quality dashboard, and rights workflow).
+15. **Initial Execution Steps** – Week‑one tasks include spinning up repos,
+    implementing pose extraction and heuristic segmentation, drafting taxonomy
+    v0.1, building a minimal upload UI, annotating sample clips, and writing
+    policies.
+16. **Implementation Blueprints** – Subsequent sections of the transcript
+    provide deeper guidance for:
+    - API contracts
+    - Queue/message schemas
+    - Storage layout
+    - Feature vectors
+    - Segmentation parameters
+    - Classifier architectures
+    - Data versioning
+    - Security considerations
+    - Testing strategy
+    - Runnable worker skeletons
+
+These notes capture the intent and methodology behind the generated codebase
+and serve as a guide for future development.


### PR DESCRIPTION
## Summary
- add a project plan summary extracted from the ChatGPT transcript
- highlight that subsequent transcript sections cover detailed implementation blueprints (API contracts, schemas, storage, ML architecture, and more)

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1209f470c8331aa00964a653e20a3